### PR TITLE
chore(release): bump add-on version after upstream AliasVault update

### DIFF
--- a/aliasvault/CHANGELOG.md
+++ b/aliasvault/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.8
+### What’s changed
+
+#### ⬆️ Upstream AliasVault update
+- Updated bundled AliasVault image from `0.28.0` to `0.28.0`.
+- Upstream release notes: https://github.com/aliasvault/aliasvault/releases/tag/0.28.0
+
+### Notes
+This remains an **unofficial community Home Assistant add-on** for AliasVault.
+For core AliasVault bugs/features, please use the upstream project:
+https://github.com/aliasvault/aliasvault
+
 ## 0.1.7
 ### What’s changed
 
@@ -18,18 +30,6 @@ https://github.com/aliasvault/aliasvault
 #### ⬆️ Upstream AliasVault update
 - Updated bundled AliasVault image from `0.27.0` to `0.27.1` (manual fallback bump).
 - Upstream release notes: https://github.com/aliasvault/aliasvault/releases/tag/0.27.1
-
-### Notes
-This remains an **unofficial community Home Assistant add-on** for AliasVault.
-For core AliasVault bugs/features, please use the upstream project:
-https://github.com/aliasvault/aliasvault
-
-## 0.1.5
-### What’s changed
-
-#### ⬆️ Upstream AliasVault update
-- Updated bundled AliasVault image from `0.26.6` to `0.27.0` (automated via Renovate).
-- Upstream release notes: https://github.com/aliasvault/aliasvault/releases/tag/v0.27.0
 
 ### Notes
 This remains an **unofficial community Home Assistant add-on** for AliasVault.

--- a/aliasvault/CHANGELOG_ARCHIVE.md
+++ b/aliasvault/CHANGELOG_ARCHIVE.md
@@ -2,6 +2,20 @@
 
 Historische wijzigingen die niet meer in de Home Assistant changelog-weergave hoeven te staan.
 
+## 0.1.5
+### What’s changed
+
+#### ⬆️ Upstream AliasVault update
+- Updated bundled AliasVault image from `0.26.6` to `0.27.0` (automated via Renovate).
+- Upstream release notes: https://github.com/aliasvault/aliasvault/releases/tag/v0.27.0
+
+### Notes
+This remains an **unofficial community Home Assistant add-on** for AliasVault.
+For core AliasVault bugs/features, please use the upstream project:
+https://github.com/aliasvault/aliasvault
+
+Oudere wijzigingen: zie `aliasvault/CHANGELOG_ARCHIVE.md` en GitHub Releases.
+
 ## 0.1.4
 ### What’s changed
 

--- a/aliasvault/config.json
+++ b/aliasvault/config.json
@@ -1,6 +1,6 @@
 {
   "name": "AliasVault",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "slug": "aliasvault",
   "description": "AliasVault for Home Assistant (community add-on)",
   "arch": [


### PR DESCRIPTION
This PR was generated after an upstream AliasVault image tag update.\n\n- Previous upstream tag: `0.27.2`\n- New upstream tag: `0.28.0`\n\nIt updates:\n- `aliasvault/config.json`\n- `aliasvault/CHANGELOG.md`\n- `aliasvault/CHANGELOG_ARCHIVE.md`